### PR TITLE
fix: remove invalid build_command config from semantic-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ disallow_untyped_defs = false
 version_toml = ["pyproject.toml:tool.poetry.version"]
 version_variables = ["src/planpilot/__init__.py:__version__"]
 commit_parser = "conventional"
-build_command = false
 tag_format = "v{version}"
 major_on_zero = false
 allow_zero_version = true


### PR DESCRIPTION
## Summary

- Remove `build_command = false` from `pyproject.toml` -- PSR expects a string, not a boolean, causing a Pydantic validation error
- The build is already correctly skipped via the action input (`build: "false"`) and handled by the `poetry build` step in the workflow

## Root cause

```
1 validation error for RawConfig
build_command
  Input should be a valid string [type=string_type, input_value=False, input_type=bool]
```

TOML `false` is a boolean, but PSR's `build_command` field only accepts strings. Removing it entirely lets the action's `build: "false"` input handle it.

## Test plan

- [x] CI passes
- [ ] Release workflow succeeds after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to allow the build command to execute during releases instead of being explicitly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->