### PR TITLE
fix(ci): add insertion flag to CHANGELOG.md for PSR update mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+<!-- version list -->
 
 ## v1.0.1 (2026-02-08)
 


### PR DESCRIPTION
## Summary

- Adds the `<!-- version list -->` insertion flag to `CHANGELOG.md`, which PSR's `mode = "update"` requires to locate where new release entries should be inserted
- This was the **actual root cause** of the changelog never being updated: without the marker, PSR silently rewrites the file unchanged ([docs](https://python-semantic-release.readthedocs.io/en/latest/concepts/changelog_templates.html#update-mode))
- Combined with `changelog: "true"` from #9, the next release should correctly append to `CHANGELOG.md`

## Root cause analysis

PSR `mode = "update"` works by splitting the existing changelog on the `insertion_flag` (default: `<!-- version list -->`). If the flag is **not found**, the file is rewritten without changes — confirmed in PSR source code:

```python
# semantic_release/cli/config.py
defaults = {
    ChangelogOutputFormat.MARKDOWN: "<!-- version list -->",
    ...
}
```

The `CHANGELOG.md` was manually created without this marker, so every automated release silently skipped the file update.

## Test plan

- [ ] Merge to main and verify the next release commit includes `CHANGELOG.md` with the new version entry
- [ ] Confirm the insertion flag remains in the file after the update (PSR preserves it by design)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->