### PR TITLE
docs: regenerate full changelog with unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 <!-- version list -->
 
+## Unreleased
+
+### Chores
+
+- Enhance OSS polish and discoverability ([#12](https://github.com/aryeko/planpilot/pull/12),
+  [`1da07ea`](https://github.com/aryeko/planpilot/commit/1da07ea88bdf991200bd21c153b14cb69455e1ac))
+
+### Documentation
+
+- Make CoC reporting private ([#12](https://github.com/aryeko/planpilot/pull/12),
+  [`1da07ea`](https://github.com/aryeko/planpilot/commit/1da07ea88bdf991200bd21c153b14cb69455e1ac))
+
+- Regenerate full changelog with all release versions
+  ([#11](https://github.com/aryeko/planpilot/pull/11),
+  [`b3d284f`](https://github.com/aryeko/planpilot/commit/b3d284f77df6177f27762de70e90b2f8f247b62e))
+
+### Testing
+
+- Suppress coverage runtime warnings in pytest config
+  ([#12](https://github.com/aryeko/planpilot/pull/12),
+  [`1da07ea`](https://github.com/aryeko/planpilot/commit/1da07ea88bdf991200bd21c153b14cb69455e1ac))
+
+
 ## v1.1.2 (2026-02-08)
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- Regenerated `CHANGELOG.md` using PSR `init` mode to rebuild from full git history
- Adds the **Unreleased** section for commits since v1.1.2
- All release versions present: v1.1.2, v1.1.1, v1.1.0, v1.0.1, v1.0.0, v0.1.0
- `<!-- version list -->` insertion flag preserved for future `update` mode releases

## Context

Follow-up to #11 which backfilled release versions but missed the unreleased section. This regeneration captures everything including commits merged after v1.1.2.

## Test plan

- [x] All 6 release versions appear in CHANGELOG.md
- [x] Unreleased section present with post-v1.1.2 commits
- [x] `<!-- version list -->` insertion flag in place
- [x] `pyproject.toml` unchanged (`mode = "update"`)

Made with [Cursor](https://cursor.com)